### PR TITLE
Added crude ping test for 2 endpoints. Integrated with Travis-CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: python
+python:
+    - "2.7"
+before_install:
+    - pip install pytest pytest-cov
+script: py.test

--- a/Tests/ballotapi_tests.py
+++ b/Tests/ballotapi_tests.py
@@ -1,0 +1,20 @@
+import sys
+import urllib
+import unittest
+import json
+import pytest
+
+
+def HasResponse(response):
+    data = json.load(response)
+    return len(data)
+
+class TestAPI:
+    HOST_NAME = 'http://50.116.6.242/'
+    
+    def test_HasElections(self):
+        assert HasResponse(urllib.urlopen(self.HOST_NAME+'api/elections/'))
+        
+    def test_HasPrecincts(self):
+        assert HasResponse(urllib.urlopen(self.HOST_NAME+'api/precincts/'))
+        


### PR DESCRIPTION
This is a very crude initial test to mainly test out the travis ci integration. We’d also have to wire travis CI to look at the ballotapi repo in git hub, which only one of you can do. Once wired up, the .yml file should just work. 
I setup a test depot to play around with various configurations that you can check out here: https://travis-ci.org/nsudarsanam/Ballot-API-tests/builds. Based on the email setup someone should receive emails about broken/fixed builds.
